### PR TITLE
`statechange` events are functionally similar to `setup`s and `teardown`s and therefore should not bubble

### DIFF
--- a/media.js
+++ b/media.js
@@ -115,7 +115,7 @@ module.exports = function(module) {
 
 			// Fire an event to allow third
 			// parties to hook into this change.
-			module.fire('statechange');
+			module.fireStatic('statechange');
 
 			// Update the matches state
 			state.matches = data.matches;


### PR DESCRIPTION
cc @AdaRoseEdwards @rowanbeentje @wilsonpage @orangemug 
