### PR TITLE
Don’t force polyfills on users

### DIFF
--- a/media.js
+++ b/media.js
@@ -10,17 +10,6 @@
 'use strict';
 
 /**
- * Locals
- */
-
-var Promise = require('es6-promise').Promise;
-require('setimmediate');
-if ('function' !== typeof setImmediate) { // PhantomJS has issues with setImmediate polyfill
-	setImmediate = setTimeout
-	clearImmediate = clearTimeout
-}
-
-/**
  * Exports
  */
 

--- a/package.json
+++ b/package.json
@@ -16,11 +16,9 @@
     "email": "ada@ada.is"
   },
   "license": "MIT",
-  "dependencies": {
-    "es6-promise": "^2.0.0",
-    "setimmediate": "~1.0.2"
-  },
   "devDependencies": {
+    "es6-promise": "^2.0.0",
+    "setimmediate": "~1.0.2",
     "buster": "^0.7.0",
     "buster-istanbul": "^0.1.10",
     "fruitmachine": "^0.8.2",

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -4,7 +4,13 @@
 
 var assert = buster.assertions.assert;
 var refute = buster.assertions.refute;
-var Promise = require('es6-promise').Promise;
+
+require('es6-promise').polyfill();
+require('setimmediate');
+if ('function' !== typeof setImmediate) { // PhantomJS has issues with setImmediate polyfill
+	setImmediate = setTimeout
+	clearImmediate = clearTimeout
+}
 
 buster.testRunner.timeout = 1000;
 


### PR DESCRIPTION
Traceur runtime has its own polyfill, and shipping both is a bit too much.